### PR TITLE
fixed vertical aligning problem

### DIFF
--- a/src/pages/about.module.scss
+++ b/src/pages/about.module.scss
@@ -20,4 +20,8 @@
   div {
     margin-top: 16px;
   }
+
+  p {
+    min-width: 330px;
+  }
 }


### PR DESCRIPTION
With this pull request, I just added a 330px minimum width to the p tag. The problem was related to improper display of text in portrait divs. This change prevents the width of the divs from changing based on the length of the content and maintains responsiveness.